### PR TITLE
Fix: Use move constructor instead of copy constructor

### DIFF
--- a/source/blender/io/ply/exporter/ply_export_load_plydata.hh
+++ b/source/blender/io/ply/exporter/ply_export_load_plydata.hh
@@ -51,7 +51,7 @@ void load_plydata(PlyData &plyData, const bContext *C)
         polyVector.append(uint32_t(loop.v + vertex_offset));
       }
 
-      plyData.faces.append(polyVector);
+      plyData.faces.append(std::move(polyVector));
     }
 
     vertex_offset = (int)plyData.vertices.size();


### PR DESCRIPTION
Exporter: Use move constructor instead of copy constructer #57