### PR TITLE
Fix: Added missing GPL headers

### DIFF
--- a/source/blender/io/ply/importer/ply_import_ascii.cc
+++ b/source/blender/io/ply/importer/ply_import_ascii.cc
@@ -1,3 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+/** \file
+ * \ingroup ply
+ */
+
 #include "ply_import_ascii.hh"
 #include "BLI_math_vector.h"
 #include "ply_functions.hh"

--- a/source/blender/io/ply/importer/ply_import_ascii.hh
+++ b/source/blender/io/ply/importer/ply_import_ascii.hh
@@ -1,3 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+/** \file
+ * \ingroup ply
+ */
+
 #ifndef BLENDER_PLY_IMPORT_ASCII_HH
 #define BLENDER_PLY_IMPORT_ASCII_HH
 

--- a/source/blender/io/ply/importer/ply_import_binary.cc
+++ b/source/blender/io/ply/importer/ply_import_binary.cc
@@ -1,3 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+/** \file
+ * \ingroup ply
+ */
+
 #include "ply_import_binary.hh"
 #include "BKE_customdata.h"
 #include "BLI_math_vector.h"

--- a/source/blender/io/ply/importer/ply_import_binary.hh
+++ b/source/blender/io/ply/importer/ply_import_binary.hh
@@ -1,3 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+/** \file
+ * \ingroup ply
+ */
+
 #ifndef BLENDER_PLY_IMPORT_BINARY_HH
 #define BLENDER_PLY_IMPORT_BINARY_HH
 

--- a/source/blender/io/ply/importer/ply_import_mesh.cc
+++ b/source/blender/io/ply/importer/ply_import_mesh.cc
@@ -1,3 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+/** \file
+ * \ingroup ply
+ */
+
 #include "ply_import_mesh.hh"
 #include "BKE_attribute.h"
 #include "BKE_customdata.h"

--- a/source/blender/io/ply/importer/ply_import_mesh.hh
+++ b/source/blender/io/ply/importer/ply_import_mesh.hh
@@ -1,3 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+/** \file
+ * \ingroup ply
+ */
+
 #ifndef BLENDER_PLY_IMPORT_MESH_HH
 #define BLENDER_PLY_IMPORT_MESH_HH
 

--- a/source/blender/io/ply/intern/ply_data.hh
+++ b/source/blender/io/ply/intern/ply_data.hh
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
 /** \file
  * \ingroup ply
  */

--- a/source/blender/io/ply/intern/ply_functions.cc
+++ b/source/blender/io/ply/intern/ply_functions.cc
@@ -1,3 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+/** \file
+ * \ingroup ply
+ */
+
 #include "ply_functions.hh"
 #include <iostream>
 

--- a/source/blender/io/ply/intern/ply_functions.hh
+++ b/source/blender/io/ply/intern/ply_functions.hh
@@ -1,3 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+/** \file
+ * \ingroup ply
+ */
+
 #ifndef BLENDER_PLY_FUNCTIONS_HH
 #define BLENDER_PLY_FUNCTIONS_HH
 


### PR DESCRIPTION
This repository is only used as a mirror of git.blender.org. Blender development happens on
https://developer.blender.org.

To get started with contributing code, please see:
https://wiki.blender.org/wiki/Process/Contributing_Code
