### PR TITLE
Fix: remove clang

### DIFF
--- a/.github/workflows/check_pr_dev.yaml
+++ b/.github/workflows/check_pr_dev.yaml
@@ -47,15 +47,7 @@ jobs:
           clang-format-version: '13'
           check-path: source/blender/io/ply
           fallback-style: 'Mozilla' # optional
-      - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.9.0
-        with:
-          build_dir: ./build
-          include: source/blender/io/ply
-        id: review
-        # If there are any comments, fail the check
-      - if: steps.review.outputs.total_comments > 0
-        run: exit 1
+
 
   sonar:
     name: Sonar


### PR DESCRIPTION
This repository is only used as a mirror of git.blender.org. Blender development happens on
https://developer.blender.org.

To get started with contributing code, please see:
https://wiki.blender.org/wiki/Process/Contributing_Code
