### PR TITLE
Feat: Vertex normals can now be imported as attribute

### DIFF
--- a/source/blender/editors/io/io_ply_ops.c
+++ b/source/blender/editors/io/io_ply_ops.c
@@ -243,6 +243,7 @@ static int wm_ply_import_execute(bContext *C, wmOperator *op)
   params.use_facet_normal = RNA_boolean_get(op->ptr, "use_facet_normal");
   params.use_scene_unit = RNA_boolean_get(op->ptr, "use_scene_unit");
   params.global_scale = RNA_float_get(op->ptr, "global_scale");
+  params.import_normals_as_attribute = RNA_boolean_get(op->ptr, "import_normals_as_attribute");
   params.use_mesh_validate = RNA_boolean_get(op->ptr, "use_mesh_validate");
 
   int files_len = RNA_collection_length(op->ptr, "files");
@@ -327,6 +328,11 @@ void WM_OT_ply_import(struct wmOperatorType *ot)
                   "Use (import) facet normals (note that this will still give flat shading)");
   RNA_def_enum(ot->srna, "forward_axis", io_transform_axis, IO_AXIS_Y, "Forward Axis", "");
   RNA_def_enum(ot->srna, "up_axis", io_transform_axis, IO_AXIS_Z, "Up Axis", "");
+  RNA_def_boolean(ot->srna,
+                  "import_normals_as_attribute",
+                  false,
+                  "Import Vertex Normals As Attribute",
+                  "Sets the vertex normal data as a vertex attribute");
   RNA_def_boolean(ot->srna,
                   "use_mesh_validate",
                   false,

--- a/source/blender/editors/io/io_ply_ops.c
+++ b/source/blender/editors/io/io_ply_ops.c
@@ -242,6 +242,7 @@ static int wm_ply_import_execute(bContext *C, wmOperator *op)
   params.up_axis = RNA_enum_get(op->ptr, "up_axis");
   params.use_scene_unit = RNA_boolean_get(op->ptr, "use_scene_unit");
   params.global_scale = RNA_float_get(op->ptr, "global_scale");
+  params.import_normals_as_attribute = RNA_boolean_get(op->ptr, "import_normals_as_attribute");
 
   int files_len = RNA_collection_length(op->ptr, "files");
 
@@ -320,6 +321,11 @@ void WM_OT_ply_import(struct wmOperatorType *ot)
                   "Apply current scene's unit (as defined by unit scale) to imported data");
   RNA_def_enum(ot->srna, "forward_axis", io_transform_axis, IO_AXIS_Y, "Forward Axis", "");
   RNA_def_enum(ot->srna, "up_axis", io_transform_axis, IO_AXIS_Z, "Up Axis", "");
+  RNA_def_boolean(ot->srna,
+                  "import_normals_as_attribute",
+                  false,
+                  "Import Vertex Normals As Attribute",
+                  "Sets the vertex normal data as a vertex attribute");
 
   /* Only show .ply files by default. */
   prop = RNA_def_string(ot->srna, "filter_glob", "*.ply", 0, "Extension Filter", "");

--- a/source/blender/editors/io/io_ply_ops.c
+++ b/source/blender/editors/io/io_ply_ops.c
@@ -324,7 +324,7 @@ void WM_OT_ply_import(struct wmOperatorType *ot)
   RNA_def_boolean(ot->srna,
                   "import_normals_as_attribute",
                   false,
-                  "Import Vertex Normals As Attribute",
+                  "Normals As Attribute",
                   "Sets the vertex normal data as a vertex attribute");
 
   /* Only show .ply files by default. */

--- a/source/blender/io/ply/IO_ply.h
+++ b/source/blender/io/ply/IO_ply.h
@@ -50,6 +50,7 @@ struct PLYImportParams {
   bool use_facet_normal;
   bool use_scene_unit;
   float global_scale;
+  bool import_normals_as_attribute;
   bool use_mesh_validate;
 };
 

--- a/source/blender/io/ply/IO_ply.h
+++ b/source/blender/io/ply/IO_ply.h
@@ -49,6 +49,7 @@ struct PLYImportParams {
   eIOAxis up_axis;
   bool use_scene_unit;
   float global_scale;
+  bool import_normals_as_attribute;
 };
 
 /**

--- a/source/blender/io/ply/importer/ply_import.cc
+++ b/source/blender/io/ply/importer/ply_import.cc
@@ -177,13 +177,13 @@ void importer_main(Main *bmain,
   Mesh *mesh = BKE_mesh_add(bmain, ob_name);
   try {
     if (header.type == PlyFormatType::ASCII) {
-      mesh = import_ply_ascii(infile, &header, mesh);
+      mesh = import_ply_ascii(infile, &header, mesh, import_params);
     }
     else if (header.type == PlyFormatType::BINARY_BE) {
-      mesh = import_ply_binary(infile, &header, mesh);
+      mesh = import_ply_binary(infile, &header, mesh, import_params);
     }
     else {
-      mesh = import_ply_binary(infile, &header, mesh);
+      mesh = import_ply_binary(infile, &header, mesh, import_params);
     }
   }
   catch (std::exception &e) {

--- a/source/blender/io/ply/importer/ply_import.cc
+++ b/source/blender/io/ply/importer/ply_import.cc
@@ -181,13 +181,13 @@ void importer_main(Main *bmain,
   Mesh *mesh = BKE_mesh_add(bmain, ob_name);
   try {
     if (header.type == PlyFormatType::ASCII) {
-      mesh = import_ply_ascii(infile, &header, mesh);
+      mesh = import_ply_ascii(infile, &header, mesh, import_params);
     }
     else if (header.type == PlyFormatType::BINARY_BE) {
-      mesh = import_ply_binary(infile, &header, mesh);
+      mesh = import_ply_binary(infile, &header, mesh, import_params);
     }
     else {
-      mesh = import_ply_binary(infile, &header, mesh);
+      mesh = import_ply_binary(infile, &header, mesh, import_params);
     }
   }
   catch (std::exception &e) {

--- a/source/blender/io/ply/importer/ply_import_ascii.cc
+++ b/source/blender/io/ply/importer/ply_import_ascii.cc
@@ -15,11 +15,11 @@
 
 namespace blender::io::ply {
 
-Mesh *import_ply_ascii(std::ifstream &file, PlyHeader *header, Mesh *mesh)
+Mesh *import_ply_ascii(std::ifstream &file, PlyHeader *header, Mesh *mesh, const PLYImportParams &params)
 {
   PlyData data = load_ply_ascii(file, header);
   if (!data.vertices.is_empty()) {
-    return convert_ply_to_mesh(data, mesh);
+    return convert_ply_to_mesh(data, mesh, params);
   }
   return nullptr;
 }

--- a/source/blender/io/ply/importer/ply_import_ascii.hh
+++ b/source/blender/io/ply/importer/ply_import_ascii.hh
@@ -10,6 +10,7 @@
 
 #include "DNA_mesh_types.h"
 
+#include "IO_ply.h"
 #include "ply_data.hh"
 
 namespace blender::io::ply {
@@ -19,7 +20,7 @@ namespace blender::io::ply {
  * @param header The information in the PLY header.
  * @return The mesh that can be used inside blender.
  */
-Mesh *import_ply_ascii(std::ifstream &file, PlyHeader *header, Mesh *mesh);
+Mesh *import_ply_ascii(std::ifstream &file, PlyHeader *header, Mesh *mesh, const PLYImportParams &params);
 
 /**
  * Loads the information from the PLY file in ASCII format to the PlyData datastructure.

--- a/source/blender/io/ply/importer/ply_import_binary.cc
+++ b/source/blender/io/ply/importer/ply_import_binary.cc
@@ -14,11 +14,11 @@
 #include <fstream>
 
 namespace blender::io::ply {
-Mesh *import_ply_binary(std::ifstream &file, const PlyHeader *header, Mesh *mesh)
+Mesh *import_ply_binary(std::ifstream &file, const PlyHeader *header, Mesh *mesh, const PLYImportParams &params)
 {
   PlyData data = load_ply_binary(file, header);
   if (!data.vertices.is_empty()) {
-    return convert_ply_to_mesh(data, mesh);
+    return convert_ply_to_mesh(data, mesh, params);
   }
   return nullptr;
 }

--- a/source/blender/io/ply/importer/ply_import_binary.hh
+++ b/source/blender/io/ply/importer/ply_import_binary.hh
@@ -10,6 +10,7 @@
 
 #include "DNA_mesh_types.h"
 
+#include "IO_ply.h"
 #include "ply_data.hh"
 
 namespace blender::io::ply {
@@ -19,7 +20,7 @@ namespace blender::io::ply {
  * @param header The information in the PLY header.
  * @return The mesh that can be used inside blender.
  */
-Mesh *import_ply_binary(std::ifstream &file, const PlyHeader *header, Mesh *mesh);
+Mesh *import_ply_binary(std::ifstream &file, const PlyHeader *header, Mesh *mesh, const PLYImportParams &params);
 
 /**
  * Loads the information from the PLY file in binary format to the PlyData datastructure.

--- a/source/blender/io/ply/importer/ply_import_mesh.hh
+++ b/source/blender/io/ply/importer/ply_import_mesh.hh
@@ -8,6 +8,7 @@
 
 #include "DNA_mesh_types.h"
 
+#include "IO_ply.h"
 #include "ply_data.hh"
 
 namespace blender::io::ply {
@@ -17,6 +18,6 @@ namespace blender::io::ply {
  * @param data The PLY data.
  * @return The mesh that can be used inside blender.
  */
-Mesh *convert_ply_to_mesh(PlyData &data, Mesh *mesh);
+Mesh *convert_ply_to_mesh(PlyData &data, Mesh *mesh, const PLYImportParams &params);
 
 }  // namespace blender::io::ply

--- a/source/blender/io/ply/tests/io_ply_importer_test.cc
+++ b/source/blender/io/ply/tests/io_ply_importer_test.cc
@@ -52,6 +52,7 @@ class PlyImportTest : public BlendfileLoadingBaseTest {
     params.global_scale = 1.0f;
     params.forward_axis = IO_AXIS_NEGATIVE_Z;
     params.up_axis = IO_AXIS_Y;
+    params.import_normals_as_attribute = true;
 
     /* Import the test file. */
     std::string ply_path = blender::tests::flags_test_asset_dir() + "/io_tests/ply/" + path;
@@ -96,8 +97,8 @@ class PlyImportTest : public BlendfileLoadingBaseTest {
         /* Fetch normal data from mesh and test if it matches expectation. */
         /* Normals are from the range -1 to 1, so this check is to see if normals are part of the
          * file. */
-        if (exp.normal_first[0] != -2) {
-          const float(*vertex_normals)[3] = BKE_mesh_vertex_normals_ensure(mesh);
+        if (BKE_mesh_has_custom_loop_normals(mesh)) {
+          const float3 *vertex_normals = (const float3 *)CustomData_get_layer_named(&mesh->vdata, CD_PROP_FLOAT3, "Normal");
           ASSERT_TRUE(vertex_normals != nullptr);
           float3 normal_first = vertex_normals != nullptr ? vertex_normals[0] : float3(0, 0, 0);
           EXPECT_V3_NEAR(normal_first, exp.normal_first, 0.0001f);

--- a/source/blender/io/ply/tests/io_ply_importer_test.cc
+++ b/source/blender/io/ply/tests/io_ply_importer_test.cc
@@ -56,7 +56,7 @@ class PlyImportTest : public BlendfileLoadingBaseTest {
     /* Import the test file. */
     std::string ply_path = blender::tests::flags_test_asset_dir() + "/io_tests/ply/" + path;
     strncpy(params.filepath, ply_path.c_str(), FILE_MAX - 1);
-    importer_main(bfile->main, bfile->curscene, bfile->cur_view_layer, params);
+    importer_main(bfile->main, bfile->curscene, bfile->cur_view_layer, params, nullptr);
 
     depsgraph_create(DAG_EVAL_VIEWPORT);
 


### PR DESCRIPTION
- Added a new option "Import Vertex Normals As Attribute"
- When checked, this adds a new vertex/point attribute called "Normal" and fills it with vertex normal data

 
