### PR TITLE
Fix: use using instead of typedef

### DIFF
--- a/source/blender/io/ply/exporter/ply_file_buffer.hh
+++ b/source/blender/io/ply/exporter/ply_file_buffer.hh
@@ -33,7 +33,7 @@ namespace blender::io::ply {
  */
 class FileBuffer : private NonMovable {
  private:
-  typedef Vector<char> VectorChar;
+  using VectorChar = Vector<char>;
   Vector<VectorChar> blocks_;
   size_t buffer_chunk_size_;
   const char *filepath_;


### PR DESCRIPTION
This repository is only used as a mirror of git.blender.org. Blender development happens on
https://developer.blender.org.

To get started with contributing code, please see:
https://wiki.blender.org/wiki/Process/Contributing_Code
