### PR TITLE
Fix: Blender crash when face vertex index was out of bounds

### DIFF
--- a/source/blender/io/ply/importer/ply_import_ascii.cc
+++ b/source/blender/io/ply/importer/ply_import_ascii.cc
@@ -121,6 +121,10 @@ PlyData load_ply_ascii(std::ifstream &file, const PlyHeader *header)
     Vector<uint> vertex_indices;
 
     for (int j = 1; j <= std::stoi(value_vec[0]); j++) {
+      /* If the face has a vertex index that is outside the range. */
+      if (std::stoi(value_vec[j]) >= data.vertices.size()) {
+        throw std::runtime_error("Vertex index out of bounds");
+      }
       vertex_indices.append(std::stoi(value_vec[j]));
     }
     data.faces.append(vertex_indices);

--- a/source/blender/io/ply/importer/ply_import_binary.cc
+++ b/source/blender/io/ply/importer/ply_import_binary.cc
@@ -118,6 +118,10 @@ PlyData load_ply_binary(std::ifstream &file, const PlyHeader *header)
         /* Loop over the amount of vertex indices in this face. */
         for (uint8_t k = 0; k < count; k++) {
           uint32_t index = read<uint32_t>(file, isBigEndian);
+          /* If the face has a vertex index that is outside the range. */
+          if (index >= data.vertices.size()) {
+            throw std::runtime_error("Vertex index out of bounds");
+          }
           vertex_indices.append(index);
         }
         data.faces.append(vertex_indices);

--- a/source/blender/io/ply/importer/ply_import_mesh.cc
+++ b/source/blender/io/ply/importer/ply_import_mesh.cc
@@ -62,7 +62,7 @@ Mesh *convert_ply_to_mesh(PlyData &data, Mesh *mesh, const PLYImportParams &para
       polys[i].totloop = size;
 
       for (int j = 0; j < size; j++) {
-        /* Set the vertex index of the edge to the one in PlyData. */
+        /* Set the vertex index of the loop to the one in PlyData. */
         loops[offset + j].v = data.faces[i][j];
       }
       offset += size;


### PR DESCRIPTION
This fixes #152 . I would've prefered it to be in import_mesh, but that was too late for Blender and it still crashed.