### PR TITLE
Fix: Remove unused BKE_mesh.h include

### DIFF
--- a/source/blender/io/ply/importer/ply_import_ascii.hh
+++ b/source/blender/io/ply/importer/ply_import_ascii.hh
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include "BKE_mesh.h"
-
 #include "DNA_mesh_types.h"
 
 #include "IO_ply.h"

--- a/source/blender/io/ply/importer/ply_import_binary.hh
+++ b/source/blender/io/ply/importer/ply_import_binary.hh
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include "BKE_mesh.h"
-
 #include "ply_data.hh"
 
 namespace blender::io::ply {


### PR DESCRIPTION
This repository is only used as a mirror of git.blender.org. Blender development happens on
https://developer.blender.org.

To get started with contributing code, please see:
https://wiki.blender.org/wiki/Process/Contributing_Code
